### PR TITLE
springdoc-openapi 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springdoc:springdoc-openapi-ui:1.6.6")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/src/main/kotlin/com/kitchenforce/configuration/OpenApiConfig.kt
+++ b/src/main/kotlin/com/kitchenforce/configuration/OpenApiConfig.kt
@@ -1,0 +1,16 @@
+package com.kitchenforce.configuration
+
+import org.springdoc.core.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+    @Bean
+    public fun api(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("apis")
+            .pathsToMatch("/api/**")
+            .build()
+    }
+}

--- a/src/main/kotlin/com/kitchenforce/controller/MenuController.kt
+++ b/src/main/kotlin/com/kitchenforce/controller/MenuController.kt
@@ -2,15 +2,19 @@ package com.kitchenforce.controller
 
 import com.kitchenforce.domain.menus.Menu
 import com.kitchenforce.service.MenuService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Menu")
 @RequestMapping("/api/menus")
 @RestController
 class MenuController(
     private val menuService: MenuService,
 ) {
+    @Operation(summary = "메뉴 목록을 반환합니다.")
     @GetMapping("/")
     fun index(): List<Menu> {
         return menuService.findAll()

--- a/src/main/kotlin/com/kitchenforce/controller/MenuGroupController.kt
+++ b/src/main/kotlin/com/kitchenforce/controller/MenuGroupController.kt
@@ -2,15 +2,19 @@ package com.kitchenforce.controller
 
 import com.kitchenforce.domain.menus.MenuGroup
 import com.kitchenforce.service.MenuGroupService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "MenuGroup")
 @RequestMapping("/api/menu-groups")
 @RestController
 class MenuGroupController(
     private val menuGroupService: MenuGroupService
 ) {
+    @Operation(summary = "메뉴 그룹 목록을 반환합니다.")
     @GetMapping("/")
     fun index(): List<MenuGroup> {
         return menuGroupService.findAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   application:
     name: kitchen-force-demo
+
+springdoc:
+  api-docs:
+    path: /api-docs


### PR DESCRIPTION
[springdoc](https://springdoc.org/) 를 추가합니다

원래 처음에는, `io.springfox:springfox-boot-starter` 를 추가하려 했었는데 [최신 스프링 버전과 이 라이브러리가 충돌하는 이슈](https://github.com/springfox/springfox/issues/3462)가 있습니다

때문에, springdoc을 추가하는 방향으로 진행해보았습니다.
결과물은 아래와 같습니다.

<img width="914" alt="image" src="https://user-images.githubusercontent.com/11086561/153734917-990c3231-ddaa-460c-91fd-3f8aa212b60f.png">
